### PR TITLE
fix: Unsupported Python version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.5-alpine
+FROM python:3.13-alpine
 
 RUN apk add --no-cache bash curl jq git \
     && curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash \
@@ -9,7 +9,7 @@ RUN apk add --no-cache bash curl jq git \
 
 USER 1001
 
-ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+ENV PATH=$PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 COPY entrypoint.sh /entrypoint.sh
 COPY cleanup.sh /cleanup.sh


### PR DESCRIPTION
Currently, doing a `docker build .` in this repo fails as the Google SDK assumes you're using a modern Python version, and thus the action is completely useless. 

This fix moves to a supported Python version. 

It also uses the new dockerfile `ENV` syntax (fixes a warning from Docker when building the container).