### PR TITLE
chore: Fix deprecation warning on `set-output`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,7 +80,7 @@ _commit() {
             echo "committing changes"
             dolt commit -m "${INPUT_COMMIT_MESSAGE}"
             head="$(dolt sql -q "select hashof('HEAD')" -r csv | head -2 | tail -1)"
-            echo "::set-output name=commit::${head}"
+            echo "commit=${head}" >> $GITHUB_OUTPUT
         fi
     fi
 }


### PR DESCRIPTION
Noticed the deprecation warning when using this action. Looked like an easy fix. 

Guide: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
